### PR TITLE
Added class for close button image

### DIFF
--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -93,6 +93,10 @@ function InfoBubble(opt_options) {
   if (options['closeSrc'] == undefined) {
     options['closeSrc'] = this.CLOSE_SRC_;
   }
+  
+  if (options['closeClass'] == undefined) {
+    options['closeClass'] = this.CLOSE_CLASS_;
+  }
 
   this.buildDom_();
   this.setValues(options);
@@ -187,6 +191,13 @@ InfoBubble.prototype.BACKGROUND_COLOR_ = '#fff';
 InfoBubble.prototype.CLOSE_SRC_ = 'https://maps.gstatic.com/intl/en_us/mapfiles/iw_close.gif';
 
 /**
+ * Default close image css class
+ * @const
+ * @private
+ */
+InfoBubble.prototype.CLOSE_CLASS_ = 'close-image';
+
+/**
  * Extends a objects prototype by anothers.
  *
  * @param {Object} obj1 The object to be extended.
@@ -223,6 +234,7 @@ InfoBubble.prototype.buildDom_ = function() {
   close.style['zIndex'] = this.baseZIndex_ + 1;
   close.style['cursor'] = 'pointer';
   close.src = this.get('closeSrc');
+  close.className = this.get('closeClass');
 
   var that = this;
   google.maps.event.addDomListener(close, 'click', function() {
@@ -780,6 +792,18 @@ InfoBubble.prototype.setCloseSrc = function(src) {
   }
 };
 InfoBubble.prototype['setCloseSrc'] = InfoBubble.prototype.setCloseSrc;
+
+/**
+ * Set the close image css class
+ *
+ * @param {string} css class of the image used as a close icon
+ */
+InfoBubble.prototype.setCloseClass = function(classname) {
+  if (classname && this.close_) {
+    this.close_.className = classname;
+  }
+};
+InfoBubble.prototype['setCloseClass'] = InfoBubble.prototype.setCloseClass;
 
 
 /**
@@ -1735,7 +1759,7 @@ InfoBubble.prototype.figureOutSize_ = function() {
   }
 
   this.contentContainer_.style['width'] = this.px(width);
-  this.contentContainer_.style['height'] = this.px(height);
+ // this.contentContainer_.style['height'] = this.px(height);
 };
 
 

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -1759,7 +1759,7 @@ InfoBubble.prototype.figureOutSize_ = function() {
   }
 
   this.contentContainer_.style['width'] = this.px(width);
- // this.contentContainer_.style['height'] = this.px(height);
+  this.contentContainer_.style['height'] = this.px(height);
 };
 
 

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -796,11 +796,11 @@ InfoBubble.prototype['setCloseSrc'] = InfoBubble.prototype.setCloseSrc;
 /**
  * Set the close image css class
  *
- * @param {string} css class of the image used as a close icon
+ * @param {string} className css class of the image used as a close icon
  */
-InfoBubble.prototype.setCloseClass = function(classname) {
-  if (classname && this.close_) {
-    this.close_.className = classname;
+InfoBubble.prototype.setCloseClass = function(className) {
+  if (className && this.close_) {
+    this.close_.className = className;
   }
 };
 InfoBubble.prototype['setCloseClass'] = InfoBubble.prototype.setCloseClass;


### PR DESCRIPTION
Added option to add close image css class. 
option name is 'closeClass'
This can be used to apply css class to close image. 
I have added this because recently I encountered problem where I want to apply some css rules to close button and there was no easiest way as per the script to achieve that. Now we can apply css class and css rules as we wish using this.
