### PR TITLE
move 'domready' trigger to onAdd() function

### DIFF
--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -846,7 +846,8 @@ InfoBubble.prototype.onAdd = function() {
     panes.floatShadow.appendChild(this.bubbleShadow_);
   }
 
-  google.maps.event.trigger(this, 'domready');          /* once the infoBubble has been added to the DOM, fire the 'domready' event */
+  /* once the infoBubble has been added to the DOM, fire 'domready' event */
+  google.maps.event.trigger(this, 'domready');
 };
 InfoBubble.prototype['onAdd'] = InfoBubble.prototype.onAdd;
 

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -301,8 +301,7 @@ InfoBubble.prototype.buildDom_ = function() {
 InfoBubble.prototype.setBackgroundClassName = function(className) {
   this.set('backgroundClassName', className);
 };
-InfoBubble.prototype['setBackgroundClassName'] =
-    InfoBubble.prototype.setBackgroundClassName;
+InfoBubble.prototype['setBackgroundClassName'] = InfoBubble.prototype.setBackgroundClassName;
 
 
 /**
@@ -311,8 +310,7 @@ InfoBubble.prototype['setBackgroundClassName'] =
 InfoBubble.prototype.backgroundClassName_changed = function() {
   this.content_.className = this.get('backgroundClassName');
 };
-InfoBubble.prototype['backgroundClassName_changed'] =
-    InfoBubble.prototype.backgroundClassName_changed;
+InfoBubble.prototype['backgroundClassName_changed'] = InfoBubble.prototype.backgroundClassName_changed;
 
 
 /**
@@ -323,8 +321,7 @@ InfoBubble.prototype['backgroundClassName_changed'] =
 InfoBubble.prototype.setTabClassName = function(className) {
   this.set('tabClassName', className);
 };
-InfoBubble.prototype['setTabClassName'] =
-    InfoBubble.prototype.setTabClassName;
+InfoBubble.prototype['setTabClassName'] = InfoBubble.prototype.setTabClassName;
 
 
 /**
@@ -333,8 +330,7 @@ InfoBubble.prototype['setTabClassName'] =
 InfoBubble.prototype.tabClassName_changed = function() {
   this.updateTabStyles_();
 };
-InfoBubble.prototype['tabClassName_changed'] =
-    InfoBubble.prototype.tabClassName_changed;
+InfoBubble.prototype['tabClassName_changed'] = InfoBubble.prototype.tabClassName_changed;
 
 
 /**
@@ -356,8 +352,7 @@ InfoBubble.prototype.getArrowStyle_ = function() {
 InfoBubble.prototype.setArrowStyle = function(style) {
   this.set('arrowStyle', style);
 };
-InfoBubble.prototype['setArrowStyle'] =
-    InfoBubble.prototype.setArrowStyle;
+InfoBubble.prototype['setArrowStyle'] = InfoBubble.prototype.setArrowStyle;
 
 
 /**
@@ -366,8 +361,7 @@ InfoBubble.prototype['setArrowStyle'] =
 InfoBubble.prototype.arrowStyle_changed = function() {
   this.arrowSize_changed();
 };
-InfoBubble.prototype['arrowStyle_changed'] =
-    InfoBubble.prototype.arrowStyle_changed;
+InfoBubble.prototype['arrowStyle_changed'] = InfoBubble.prototype.arrowStyle_changed;
 
 
 /**
@@ -389,8 +383,7 @@ InfoBubble.prototype.getArrowSize_ = function() {
 InfoBubble.prototype.setArrowSize = function(size) {
   this.set('arrowSize', size);
 };
-InfoBubble.prototype['setArrowSize'] =
-    InfoBubble.prototype.setArrowSize;
+InfoBubble.prototype['setArrowSize'] = InfoBubble.prototype.setArrowSize;
 
 
 /**
@@ -399,8 +392,7 @@ InfoBubble.prototype['setArrowSize'] =
 InfoBubble.prototype.arrowSize_changed = function() {
   this.borderWidth_changed();
 };
-InfoBubble.prototype['arrowSize_changed'] =
-    InfoBubble.prototype.arrowSize_changed;
+InfoBubble.prototype['arrowSize_changed'] = InfoBubble.prototype.arrowSize_changed;
 
 
 /**
@@ -411,8 +403,7 @@ InfoBubble.prototype['arrowSize_changed'] =
 InfoBubble.prototype.setArrowPosition = function(pos) {
   this.set('arrowPosition', pos);
 };
-InfoBubble.prototype['setArrowPosition'] =
-    InfoBubble.prototype.setArrowPosition;
+InfoBubble.prototype['setArrowPosition'] = InfoBubble.prototype.setArrowPosition;
 
 
 /**
@@ -435,8 +426,7 @@ InfoBubble.prototype.arrowPosition_changed = function() {
 
   this.redraw_();
 };
-InfoBubble.prototype['arrowPosition_changed'] =
-    InfoBubble.prototype.arrowPosition_changed;
+InfoBubble.prototype['arrowPosition_changed'] = InfoBubble.prototype.arrowPosition_changed;
 
 
 /**
@@ -525,8 +515,7 @@ InfoBubble.prototype.shadowStyle_changed = function() {
     this.draw();
   }
 };
-InfoBubble.prototype['shadowStyle_changed'] =
-    InfoBubble.prototype.shadowStyle_changed;
+InfoBubble.prototype['shadowStyle_changed'] = InfoBubble.prototype.shadowStyle_changed;
 
 
 /**
@@ -553,8 +542,7 @@ InfoBubble.prototype['hideCloseButton'] = InfoBubble.prototype.hideCloseButton;
 InfoBubble.prototype.hideCloseButton_changed = function() {
   this.close_.style['display'] = this.get('hideCloseButton') ? 'none' : '';
 };
-InfoBubble.prototype['hideCloseButton_changed'] =
-    InfoBubble.prototype.hideCloseButton_changed;
+InfoBubble.prototype['hideCloseButton_changed'] = InfoBubble.prototype.hideCloseButton_changed;
 
 
 /**
@@ -567,8 +555,7 @@ InfoBubble.prototype.setBackgroundColor = function(color) {
     this.set('backgroundColor', color);
   }
 };
-InfoBubble.prototype['setBackgroundColor'] =
-    InfoBubble.prototype.setBackgroundColor;
+InfoBubble.prototype['setBackgroundColor'] = InfoBubble.prototype.setBackgroundColor;
 
 
 /**
@@ -582,8 +569,7 @@ InfoBubble.prototype.backgroundColor_changed = function() {
       ' transparent transparent';
   this.updateTabStyles_();
 };
-InfoBubble.prototype['backgroundColor_changed'] =
-    InfoBubble.prototype.backgroundColor_changed;
+InfoBubble.prototype['backgroundColor_changed'] = InfoBubble.prototype.backgroundColor_changed;
 
 
 /**
@@ -618,8 +604,7 @@ InfoBubble.prototype.borderColor_changed = function() {
 
   this.updateTabStyles_();
 };
-InfoBubble.prototype['borderColor_changed'] =
-    InfoBubble.prototype.borderColor_changed;
+InfoBubble.prototype['borderColor_changed'] = InfoBubble.prototype.borderColor_changed;
 
 
 /**
@@ -664,8 +649,7 @@ InfoBubble.prototype.borderRadius_changed = function() {
 
   this.redraw_();
 };
-InfoBubble.prototype['borderRadius_changed'] =
-    InfoBubble.prototype.borderRadius_changed;
+InfoBubble.prototype['borderRadius_changed'] = InfoBubble.prototype.borderRadius_changed;
 
 
 /**
@@ -704,8 +688,7 @@ InfoBubble.prototype.borderWidth_changed = function() {
   this.borderRadius_changed();
   this.redraw_();
 };
-InfoBubble.prototype['borderWidth_changed'] =
-    InfoBubble.prototype.borderWidth_changed;
+InfoBubble.prototype['borderWidth_changed'] = InfoBubble.prototype.borderWidth_changed;
 
 
 /**
@@ -862,6 +845,8 @@ InfoBubble.prototype.onAdd = function() {
     panes.floatPane.appendChild(this.bubble_);
     panes.floatShadow.appendChild(this.bubbleShadow_);
   }
+
+  google.maps.event.trigger(this, 'domready');          /* once the infoBubble has been added to the DOM, fire the 'domready' event */
 };
 InfoBubble.prototype['onAdd'] = InfoBubble.prototype.onAdd;
 
@@ -1010,6 +995,7 @@ InfoBubble.prototype.open = function(opt_map, opt_anchor) {
   }, 0);
 };
 
+
 /**
  * Open the InfoBubble
  * @private
@@ -1084,8 +1070,7 @@ InfoBubble.prototype['getPosition'] = InfoBubble.prototype.getPosition;
 InfoBubble.prototype.position_changed = function() {
   this.draw();
 };
-InfoBubble.prototype['position_changed'] =
-    InfoBubble.prototype.position_changed;
+InfoBubble.prototype['position_changed'] = InfoBubble.prototype.position_changed;
 
 
 /**
@@ -1228,10 +1213,10 @@ InfoBubble.prototype.updateContent_ = function() {
         that.imageLoaded_();
       });
     }
-    google.maps.event.trigger(this, 'domready');
   }
   this.redraw_();
 };
+
 
 /**
  * Image loaded
@@ -1244,6 +1229,7 @@ InfoBubble.prototype.imageLoaded_ = function() {
     this.panToView();
   }
 };
+
 
 /**
  * Updates the styles of the tabs
@@ -1395,8 +1381,7 @@ InfoBubble.prototype['setMaxWidth'] = InfoBubble.prototype.setMaxWidth;
 InfoBubble.prototype.maxWidth_changed = function() {
   this.redraw_();
 };
-InfoBubble.prototype['maxWidth_changed'] =
-    InfoBubble.prototype.maxWidth_changed;
+InfoBubble.prototype['maxWidth_changed'] = InfoBubble.prototype.maxWidth_changed;
 
 
 /**
@@ -1416,8 +1401,7 @@ InfoBubble.prototype['setMaxHeight'] = InfoBubble.prototype.setMaxHeight;
 InfoBubble.prototype.maxHeight_changed = function() {
   this.redraw_();
 };
-InfoBubble.prototype['maxHeight_changed'] =
-    InfoBubble.prototype.maxHeight_changed;
+InfoBubble.prototype['maxHeight_changed'] = InfoBubble.prototype.maxHeight_changed;
 
 
 /**
@@ -1437,8 +1421,7 @@ InfoBubble.prototype['setMinWidth'] = InfoBubble.prototype.setMinWidth;
 InfoBubble.prototype.minWidth_changed = function() {
   this.redraw_();
 };
-InfoBubble.prototype['minWidth_changed'] =
-    InfoBubble.prototype.minWidth_changed;
+InfoBubble.prototype['minWidth_changed'] = InfoBubble.prototype.minWidth_changed;
 
 
 /**
@@ -1458,8 +1441,7 @@ InfoBubble.prototype['setMinHeight'] = InfoBubble.prototype.setMinHeight;
 InfoBubble.prototype.minHeight_changed = function() {
   this.redraw_();
 };
-InfoBubble.prototype['minHeight_changed'] =
-    InfoBubble.prototype.minHeight_changed;
+InfoBubble.prototype['minHeight_changed'] = InfoBubble.prototype.minHeight_changed;
 
 
 /**
@@ -1495,6 +1477,7 @@ InfoBubble.prototype.addTab = function(label, content) {
   this.redraw_();
 };
 InfoBubble.prototype['addTab'] = InfoBubble.prototype.addTab;
+
 
 /**
  * Update a tab at a speicifc index


### PR DESCRIPTION
fixes #10:
- line 849 - move the 'domready' trigger from updateContent_() into the onAdd() function - so that the 'domready' event is fired after the infoBubble is appended to the map panes (& therefore) added to the DOM (or it's impossible to dynamically add / find the infoBubble after the 'domready' without using a setTimeout or other hack)
- minor code clean-up for consistency in spacing and line breaks
