### PR TITLE
update the infobubble autopan functionality:

### DIFF
--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -70,6 +70,10 @@ function InfoBubble(opt_options) {
     options['disableAutoPan'] = false;
   }
 
+  if (options['autopanMargin'] == undefined) {
+    options['autopanMargin'] = this.AUTOPAN_MARGIN_;
+  }
+
   if (options['disableAnimation'] == undefined) {
     options['disableAnimation'] = false;
   }
@@ -178,6 +182,13 @@ InfoBubble.prototype.BORDER_RADIUS_ = 10;
  * @private
  */
 InfoBubble.prototype.BACKGROUND_COLOR_ = '#fff';
+
+/**
+ * Default autopan margin (from any edge)
+ * @const
+ * @private
+ */
+InfoBubble.prototype.AUTOPAN_MARGIN_ = 10;
 
 /**
  * Default close image source
@@ -1092,6 +1103,7 @@ InfoBubble.prototype['position_changed'] =
  * Pan the InfoBubble into view
  */
 InfoBubble.prototype.panToView = function() {
+	
   var projection = this.getProjection();
 
   if (!projection) {
@@ -1104,39 +1116,42 @@ InfoBubble.prototype.panToView = function() {
     return;
   }
 
-  var anchorHeight = this.getAnchorHeight_();
-  var height = this.bubble_.offsetHeight + anchorHeight;
+  var autopanMargin = this.get('autopanMargin');										// get the edge margin from options (or default)
+  var anchorHeight = this.getAnchorHeight_();											// height of the marker icon - pixels
+  var infobubbleHeight = this.bubble_.offsetHeight;									    // height of the infobubble - pixels
+  var infobubbleWidth = this.bubble_.offsetWidth;									    // width of the infobubble - pixels
+
   var map = this.get('map');
-  var mapDiv = map.getDiv();
-  var mapHeight = mapDiv.offsetHeight;
+  var mapDiv = map.getDiv();															// the div containing the map
+  var mapHeight = mapDiv.offsetHeight;											    	// height of the div containing the map - pixels
+  var mapWidth = mapDiv.offsetWidth;													// height of the div containing the map - pixels
 
-  var latLng = this.getPosition();
-  var centerPos = projection.fromLatLngToContainerPixel(map.getCenter());
-  var pos = projection.fromLatLngToContainerPixel(latLng);
+  var markerLatLng = this.getPosition();												// coordinate of the marker - lat/lng
+  var markerPosition = projection.fromLatLngToContainerPixel(markerLatLng);				// the marker position - pixels
 
-  // Find out how much space at the top is free
-  var spaceTop = centerPos.y - height;
+  var mapCenter = projection.fromLatLngToContainerPixel(map.getCenter());			    // centre of the map - pixels
 
-  // Fine out how much space at the bottom is free
-  var spaceBottom = mapHeight - centerPos.y;
-
-  var needsTop = spaceTop < 0;
-  var deltaY = 0;
-
-  if (needsTop) {
-    spaceTop *= -1;
-    deltaY = (spaceTop + spaceBottom) / 2;
+  var spaceTop = markerPosition.y - infobubbleHeight - anchorHeight - autopanMargin;	// Find out how much space at the top is free (including the autopan margin) - pixels
+  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth/2 - autopanMargin;		// Find out how much space at the top is free (including the autopan margin) - pixels
+  var spaceLeft =  markerPosition.x - infobubbleWidth/2 - autopanMargin;				// Find out how much space at the top is free (including the autopan margin) - pixels
+  
+  if(spaceTop<0){
+	  mapCenter.y += spaceTop;				// if spaceTop is -ve, we have to move the map centre UP (ie delete the difference from the y-axis value) - hence we add the -ve spaceTop value
+  }
+  if(spaceRight<0){
+	  mapCenter.x -= spaceRight;			// if spaceRight is -ve, we have to move the map centre RIGHT (ie add the difference to the x-axis value) - hence we minus the -ve spaceRight value
+  }
+  if(spaceLeft<0){
+	  mapCenter.x += spaceLeft;				// if spaceLeft is -ve, we have to move the map centre LEFT (ie delete the difference to the x-axis value) - hence we add the -ve spaceRight value
   }
 
-  pos.y -= deltaY;
-  latLng = projection.fromContainerPixelToLatLng(pos);
+  newMapCenterlatLng = projection.fromContainerPixelToLatLng(mapCenter);
 
-  if (map.getCenter() != latLng) {
-    map.panTo(latLng);
+  if (map.getCenter() != newMapCenterlatLng) {										
+    map.panTo(newMapCenterlatLng);
   }
 };
 InfoBubble.prototype['panToView'] = InfoBubble.prototype.panToView;
-
 
 /**
  * Converts a HTML string to a document fragment.

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -1779,8 +1779,6 @@ InfoBubble.prototype.figureOutSize_ = function() {
 /**
  *  Get the height of the anchor
  *
- *  This function is a hack for now and doesn't really work that good, need to
- *  wait for pixelBounds to be correctly exposed.
  *  @private
  *  @return {number} The height of the anchor.
  */

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -1107,12 +1107,12 @@ InfoBubble.prototype.panToView = function() {
   var projection = this.getProjection();
 
   if (!projection) {
-    // The map projection is not ready yet so do nothing
+  // The map projection is not ready yet so do nothing
     return;
   }
 
   if (!this.bubble_) {
-    // No Bubble yet so do nothing
+  // No Bubble yet so do nothing
     return;
   }
   // get the edge margin from options (or default)
@@ -1142,32 +1142,34 @@ InfoBubble.prototype.panToView = function() {
   // centre of the map - pixels
   var mapCenter = projection.fromLatLngToContainerPixel(map.getCenter());
   // calculate top free space or overrun (incl autopan margin) - pixels
-  var spaceTop = markerPosition.y - infobubbleHeight - arrowHeight - anchorHeight - autopanMargin;
+  var spaceTop = markerPosition.y - infobubbleHeight - arrowHeight 
+  - anchorHeight - autopanMargin;
   // calculate right side free space or overrun (incl autopan margin) - pixels
-  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth/2 - autopanMargin;
+  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth / 2 
+  - autopanMargin;
   // calculate left side free space or overrun (incl autopan margin) - pixels
-  var spaceLeft =  markerPosition.x - infobubbleWidth/2 - autopanMargin;
+  var spaceLeft =  markerPosition.x - infobubbleWidth / 2 - autopanMargin;
   
-  if(spaceTop < 0){
-	/* if spaceTop is -ve, we have to move the map centre UP
-	(ie delete the difference from the y-axis value)
-	hence we add the -ve spaceTop value */
+  if(spaceTop < 0) {
+  /* if spaceTop is -ve, we have to move the map centre UP
+  (ie delete the difference from the y-axis value)
+  hence we add the -ve spaceTop value */
 	mapCenter.y += spaceTop;
   }
-  if(spaceRight < 0){
-	/* if spaceRight is -ve, we have to move the map centre RIGHT
-	(ie add the difference to the x-axis value)
-	hence we minus the -ve spaceRight value */
+  if(spaceRight < 0) {
+  /* if spaceRight is -ve, we have to move the map centre RIGHT
+  (ie add the difference to the x-axis value)
+  hence we minus the -ve spaceRight value */
 	mapCenter.x -= spaceRight;
   }
-  if(spaceLeft < 0){
-    /* if spaceLeft is -ve, we have to move the map centre LEFT
-	(ie delete the difference to the x-axis value)
-	hence we add the -ve spaceRight value */
+  if(spaceLeft < 0) {
+  /* if spaceLeft is -ve, we have to move the map centre LEFT
+  (ie delete the difference to the x-axis value)
+  hence we add the -ve spaceRight value */
 	mapCenter.x += spaceLeft;
   }
 
-  newMapCenterlatLng = projection.fromContainerPixelToLatLng(mapCenter);
+  var newMapCenterlatLng = projection.fromContainerPixelToLatLng(mapCenter);
 
   if (map.getCenter() != newMapCenterlatLng) {										
     map.panTo(newMapCenterlatLng);

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -1118,6 +1118,7 @@ InfoBubble.prototype.panToView = function() {
 
   var autopanMargin = this.get('autopanMargin');										// get the edge margin from options (or default)
   var anchorHeight = this.getAnchorHeight_();											// height of the marker icon - pixels
+  var arrowHeight = this.getArrowSize_();												// height of the infobubble bottom arrow - pixels
   var infobubbleHeight = this.bubble_.offsetHeight;									    // height of the infobubble - pixels
   var infobubbleWidth = this.bubble_.offsetWidth;									    // width of the infobubble - pixels
 
@@ -1131,9 +1132,9 @@ InfoBubble.prototype.panToView = function() {
 
   var mapCenter = projection.fromLatLngToContainerPixel(map.getCenter());			    // centre of the map - pixels
 
-  var spaceTop = markerPosition.y - infobubbleHeight - anchorHeight - autopanMargin;	// Find out how much space at the top is free (including the autopan margin) - pixels
-  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth/2 - autopanMargin;		// Find out how much space at the top is free (including the autopan margin) - pixels
-  var spaceLeft =  markerPosition.x - infobubbleWidth/2 - autopanMargin;				// Find out how much space at the top is free (including the autopan margin) - pixels
+  var spaceTop = markerPosition.y - infobubbleHeight - arrowHeight - anchorHeight - autopanMargin;	// calculate free space or overrun at the top (including the autopan margin) - pixels
+  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth/2 - autopanMargin;		// calculate free space or overrun on the right (including the autopan margin) - pixels
+  var spaceLeft =  markerPosition.x - infobubbleWidth/2 - autopanMargin;				// calculate free space or overrun on the left (including the autopan margin) - pixels
   
   if(spaceTop<0){
 	  mapCenter.y += spaceTop;				// if spaceTop is -ve, we have to move the map centre UP (ie delete the difference from the y-axis value) - hence we add the -ve spaceTop value

--- a/src/infobubble.js
+++ b/src/infobubble.js
@@ -1115,35 +1115,56 @@ InfoBubble.prototype.panToView = function() {
     // No Bubble yet so do nothing
     return;
   }
-
-  var autopanMargin = this.get('autopanMargin');										// get the edge margin from options (or default)
-  var anchorHeight = this.getAnchorHeight_();											// height of the marker icon - pixels
-  var arrowHeight = this.getArrowSize_();												// height of the infobubble bottom arrow - pixels
-  var infobubbleHeight = this.bubble_.offsetHeight;									    // height of the infobubble - pixels
-  var infobubbleWidth = this.bubble_.offsetWidth;									    // width of the infobubble - pixels
+  // get the edge margin from options (or default)
+  var autopanMargin = this.get('autopanMargin');
+  // height of the marker icon - pixels
+  var anchorHeight = this.getAnchorHeight_();
+  // height of the infobubble bottom arrow - pixels
+  var arrowHeight = this.getArrowSize_();
+  // height of the infobubble - pixels
+  var infobubbleHeight = this.bubble_.offsetHeight;
+  // width of the infobubble - pixels
+  var infobubbleWidth = this.bubble_.offsetWidth;
 
   var map = this.get('map');
-  var mapDiv = map.getDiv();															// the div containing the map
-  var mapHeight = mapDiv.offsetHeight;											    	// height of the div containing the map - pixels
-  var mapWidth = mapDiv.offsetWidth;													// height of the div containing the map - pixels
+  // the div containing the map
+  var mapDiv = map.getDiv();
+  // height of the div containing the map - pixels
+  var mapHeight = mapDiv.offsetHeight;
+  // height of the div containing the map - pixels
+  var mapWidth = mapDiv.offsetWidth;
 
-  var markerLatLng = this.getPosition();												// coordinate of the marker - lat/lng
-  var markerPosition = projection.fromLatLngToContainerPixel(markerLatLng);				// the marker position - pixels
+  // coordinate of the marker - lat/lng
+  var markerLatLng = this.getPosition();
+  // the marker position - pixels
+  var markerPosition = projection.fromLatLngToContainerPixel(markerLatLng);
 
-  var mapCenter = projection.fromLatLngToContainerPixel(map.getCenter());			    // centre of the map - pixels
-
-  var spaceTop = markerPosition.y - infobubbleHeight - arrowHeight - anchorHeight - autopanMargin;	// calculate free space or overrun at the top (including the autopan margin) - pixels
-  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth/2 - autopanMargin;		// calculate free space or overrun on the right (including the autopan margin) - pixels
-  var spaceLeft =  markerPosition.x - infobubbleWidth/2 - autopanMargin;				// calculate free space or overrun on the left (including the autopan margin) - pixels
+  // centre of the map - pixels
+  var mapCenter = projection.fromLatLngToContainerPixel(map.getCenter());
+  // calculate top free space or overrun (incl autopan margin) - pixels
+  var spaceTop = markerPosition.y - infobubbleHeight - arrowHeight - anchorHeight - autopanMargin;
+  // calculate right side free space or overrun (incl autopan margin) - pixels
+  var spaceRight = mapWidth - markerPosition.x - infobubbleWidth/2 - autopanMargin;
+  // calculate left side free space or overrun (incl autopan margin) - pixels
+  var spaceLeft =  markerPosition.x - infobubbleWidth/2 - autopanMargin;
   
-  if(spaceTop<0){
-	  mapCenter.y += spaceTop;				// if spaceTop is -ve, we have to move the map centre UP (ie delete the difference from the y-axis value) - hence we add the -ve spaceTop value
+  if(spaceTop < 0){
+	/* if spaceTop is -ve, we have to move the map centre UP
+	(ie delete the difference from the y-axis value)
+	hence we add the -ve spaceTop value */
+	mapCenter.y += spaceTop;
   }
-  if(spaceRight<0){
-	  mapCenter.x -= spaceRight;			// if spaceRight is -ve, we have to move the map centre RIGHT (ie add the difference to the x-axis value) - hence we minus the -ve spaceRight value
+  if(spaceRight < 0){
+	/* if spaceRight is -ve, we have to move the map centre RIGHT
+	(ie add the difference to the x-axis value)
+	hence we minus the -ve spaceRight value */
+	mapCenter.x -= spaceRight;
   }
-  if(spaceLeft<0){
-	  mapCenter.x += spaceLeft;				// if spaceLeft is -ve, we have to move the map centre LEFT (ie delete the difference to the x-axis value) - hence we add the -ve spaceRight value
+  if(spaceLeft < 0){
+    /* if spaceLeft is -ve, we have to move the map centre LEFT
+	(ie delete the difference to the x-axis value)
+	hence we add the -ve spaceRight value */
+	mapCenter.x += spaceLeft;
   }
 
   newMapCenterlatLng = projection.fromContainerPixelToLatLng(mapCenter);


### PR DESCRIPTION
this updates the autopan functionality to bring it inline with (ahead of ?)  the standard `google.maps.InfoWindow()` autopan:
- so map is only panned enough for the `infobubble` window to be visible with an edge margin - as per 
- add an `autopanMargin` option to set the margin between the map edge and the infobubble window (with default = 10px)
- better variable naming & comments in `panToView()` function

remove comment about the use of `anchorPoint` being a hack - since `pixelBounds` has been deprecated
