### PR TITLE
Add bower support (fix bower.json + add tags)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,5 +19,5 @@
     "api",
     "v3"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache 2.0"
 }


### PR DESCRIPTION
- fix malformed bower.json (remove unnecessary comma after "license")

@skarEE  or @markmcd please tag the latest commit (or after the next merged pull request) with branch master and the package version. It's currently impossible to register this package on bower as there are no tags (on any commits).
- currently getting the error `ENORESTARGET Tag/branch master does not exist`
- tags can't be added as part of a pull request (http://stackoverflow.com/a/12279290/3092596)

It is recommended to add a 3rd integer to the version number (eg 0.8.0 rather than just 0.8 )
as per:
- http://semver.org/  
- http://bower.io/docs/creating-packages/#register

This will allow more frequent tagging - potentially after each pull merge - and hence more frequent bower updates for users.

If you want to register it yourself, please run the following (after adding the appropriate tags to the latest commit):
`bower register js-info-bubble git://github.com/googlemaps/js-info-bubble.git`
